### PR TITLE
[issues/48] Implement requirement #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Scheduler App allows users to schedule, manage, and track application executions
 
 - **Schedule Applications**: Set specific times for apps to execute
 - **Manage Schedules**: Cancel or modify existing schedules as needed
-- **Time Conflict Detection**: Get alerts when attempting to schedule two apps at the same time
+- **Time Conflict Detection**: Set at most 11 apps to execute at a specific time. Get alerts when attempting to schedule more than 11 apps at the same time
 - **Execution History**: View complete execution history for each application
 - **Visual Status Tracking**: Color-coded states make it easy to identify schedule status at a glance
 

--- a/app/src/main/java/com/example/appscheduler/data/model/Schedule.kt
+++ b/app/src/main/java/com/example/appscheduler/data/model/Schedule.kt
@@ -26,6 +26,8 @@ data class Schedule(
     val packageName: String,
     @SerializedName("scheduled_time")
     val scheduledTime: Long,
+    @SerializedName("scheduled_time_offset")
+    var scheduledTimeOffset: Int,
     @SerializedName("state")
     var state: ScheduleState = ScheduleState.SCHEDULED
 )

--- a/app/src/main/java/com/example/appscheduler/receivers/BootReceiver.kt
+++ b/app/src/main/java/com/example/appscheduler/receivers/BootReceiver.kt
@@ -13,6 +13,7 @@ import com.example.appscheduler.util.Constants.KEY_PACKAGE_NAME
 import com.example.appscheduler.util.Constants.KEY_PREF_SCHEDULES
 import com.example.appscheduler.util.Constants.KEY_SCHEDULE_ID
 import com.example.appscheduler.util.Constants.NAME_PREF_SCHEDULE
+import com.example.appscheduler.util.Constants.ONE_SECOND
 import com.example.appscheduler.util.Constants.TAG
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -55,7 +56,7 @@ class BootReceiver : BroadcastReceiver() {
 
                     alarmManager.setExactAndAllowWhileIdle(
                         AlarmManager.RTC_WAKEUP,
-                        schedule.scheduledTime,
+                        schedule.scheduledTime + schedule.scheduledTimeOffset * ONE_SECOND,
                         pendingIntent
                     )
                 }

--- a/app/src/main/java/com/example/appscheduler/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/appscheduler/ui/screens/HomeScreen.kt
@@ -219,7 +219,7 @@ fun AppStateIndicator(packageName: String, context: Context, scheduleViewModel: 
     val appStateChangeListener = AppStateRepository.appStatesChanged.collectAsState().value
 
     val appStates = AppStateRepository.appStates.collectAsState().value
-    val appState = appStates[packageName]!!
+    val appState = appStates[packageName]?: ScheduleState.NOT_SCHEDULED
     Log.i(TAG, "state: $appState for package: $packageName with color: ${appState.color}")
 
     Card (

--- a/app/src/main/java/com/example/appscheduler/ui/screens/ScheduleDialog.kt
+++ b/app/src/main/java/com/example/appscheduler/ui/screens/ScheduleDialog.kt
@@ -83,7 +83,8 @@ fun ScheduleDialog(
                         val schedule = Schedule(
                             packageName = app.packageName,
                             scheduledTime = selectedTime,
-                            state = ScheduleState.SCHEDULED
+                            state = ScheduleState.SCHEDULED,
+                            scheduledTimeOffset = 0
                         )
                         val prevState = AppStateRepository.appStates.value[app.packageName]
                         val scheduleDone = viewModel.scheduleApp(schedule)

--- a/app/src/main/java/com/example/appscheduler/util/Constants.kt
+++ b/app/src/main/java/com/example/appscheduler/util/Constants.kt
@@ -8,4 +8,5 @@ object Constants {
     const val KEY_SCHEDULE_ID = "key_schedule_id"
     const val NAME_PREF_SCHEDULE = "schedule_pref"
     const val KEY_PREF_SCHEDULES = "schedules"
+    const val ONE_SECOND = 1000L
 }


### PR DESCRIPTION
[Problem] User couldn't able to set multiple schedule at the same exact minute of time stamp. 
[Cause] This case was handled by a Toast alert and restricted user not schedule more than one app at the same exact time. [Measure] Now it is handled by allowing user to schedule at most 11 apps at the same time by setting the timestamp by an offset of multiple of 5. 

[Issue path]

Closes #48 